### PR TITLE
Apply Chrome rounded-corner `corner-shape: squircle` globally

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -64,6 +64,12 @@ a {
   box-sizing: border-box;
 }
 
+@supports (corner-shape: squircle) {
+  * {
+    corner-shape: squircle;
+  }
+}
+
 .timer {
   font-variant-numeric: tabular-nums;
 }


### PR DESCRIPTION
### Motivation
- Use Chrome's new rounded-corner shaping to give all existing rounded borders a squircle profile while leaving unsupported browsers unaffected.

### Description
- Add a progressive-enhancement `@supports (corner-shape: squircle)` block to `styles/globals.css` that sets `corner-shape: squircle` on `*`, so existing `border-radius` rules adopt the new corner profile in supporting browsers.

### Testing
- Ran `npm run lint` which failed in this environment because `next` is not installed (tooling not available). 
- Ran `npm install` which failed with a `403 Forbidden` from the npm registry for `@openpanel/nextjs`, blocking dependency installation. 
- Attempted a Playwright page screenshot of the running app which failed because the dev server was not reachable at `http://127.0.0.1:3000` due to the above installation/start issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699386ff6d2c8331baa386f5518bf655)