### PR TITLE
Apply Torph-style text morph to Settings/Close button

### DIFF
--- a/components/Pomodoro.tsx
+++ b/components/Pomodoro.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useRef } from 'react';
 import * as Tone from 'tone';
 import { motion, AnimatePresence } from 'framer-motion';
 import NotificationControls from 'components/NotificationControls';
+import { TextMorph } from './TextMorph';
 import * as Switch from '@radix-ui/react-switch';
 import * as Toast from '@radix-ui/react-toast';
 import * as Slider from '@radix-ui/react-slider';
@@ -818,7 +819,7 @@ export default function Pomodoro() {
                   </g>
                 </svg>
               )}
-              {!settingsOpen && ' Settings'}
+              <TextMorph>{settingsOpen ? ' Close' : ' Settings'}</TextMorph>
 
               {settingsOpen && (
                 <svg
@@ -837,7 +838,6 @@ export default function Pomodoro() {
                   />
                 </svg>
               )}
-              {settingsOpen && ' Close'}
             </motion.button>
           </Popover.Trigger>
           <Popover.Portal>

--- a/components/TextMorph.tsx
+++ b/components/TextMorph.tsx
@@ -1,0 +1,25 @@
+import { AnimatePresence, motion } from 'framer-motion';
+
+type TextMorphProps = {
+  children: string;
+  className?: string;
+};
+
+export function TextMorph({ children, className }: TextMorphProps) {
+  return (
+    <span className={className} aria-live="polite">
+      <AnimatePresence mode="wait" initial={false}>
+        <motion.span
+          key={children}
+          className="torphText"
+          initial={{ opacity: 0, y: 3, filter: 'blur(3px)' }}
+          animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
+          exit={{ opacity: 0, y: -3, filter: 'blur(3px)' }}
+          transition={{ duration: 0.2, ease: [0.19, 1, 0.22, 1] }}
+        >
+          {children}
+        </motion.span>
+      </AnimatePresence>
+    </span>
+  );
+}

--- a/styles/pomodoro.css
+++ b/styles/pomodoro.css
@@ -405,3 +405,7 @@
     margin-bottom: 24px;
   }
 }
+
+.torphText {
+  display: inline-block;
+}


### PR DESCRIPTION
### Motivation
- Provide a Torph-style animated label for the settings trigger so the button label morphs between `Settings` and `Close` for a smoother UI interaction.
- Direct `torph` package installation was attempted but blocked by the environment/network, so implement a lightweight in-repo equivalent to achieve the same UX.

### Description
- Added a reusable `TextMorph` React component that uses `framer-motion` to animate short label swaps (`components/TextMorph.tsx`).
- Wired the settings trigger in `components/Pomodoro.tsx` to render `<TextMorph>{settingsOpen ? ' Close' : ' Settings'}</TextMorph>` and imported the new component.
- Added a minimal CSS rule `.torphText { display: inline-block; }` to `styles/pomodoro.css` to ensure correct layout of the morphing text.
- Note: an attempt to install the upstream `torph` package failed due to registry/network 403, so the effect is implemented locally instead.

### Testing
- Ran `npm run lint`, which failed in this environment because `next`/project dependencies are not available (command error: `next: not found`).
- Attempted a headless browser render/screenshot via Playwright to capture the updated button, but the run failed due to Chromium/Playwright crashes in this environment (SIGSEGV), so no visual snapshot was produced.
- Local git operations (add/commit) completed successfully and the changes are committed on branch `e2e2fd0`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69938d3d450883319fcacbdf74d7275a)